### PR TITLE
Add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+
+requires = ["setuptools",
+            "wheel",
+            "oldest-supported-numpy"]
+
+build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
This pyproject.toml file will enable installing afterglowpy from source even in Python environments that do not yet contain numpy.